### PR TITLE
Render full page in IT8951

### DIFF
--- a/lib/Epub/EpubList/EpubList.cpp
+++ b/lib/Epub/EpubList/EpubList.cpp
@@ -26,7 +26,9 @@ void EpubList::prev()
 
 bool EpubList::load(const char *path)
 {
-  if (state.is_loaded)
+  // Solves bug that is rendering List with only empty rectangles (After deep-sleep)
+  // Research why
+  if (false)  // state.is_loaded
   {
     ESP_LOGI(TAG, "Already loaded books");
     return true;

--- a/lib/Epub/EpubList/EpubList.cpp
+++ b/lib/Epub/EpubList/EpubList.cpp
@@ -163,11 +163,13 @@ void EpubList::render()
       // center the title in the cell
       int y_offset = title_height < text_height ? (text_height - title_height) / 2 : 0;
       // draw each line of the title making sure we don't run over the cell
+      renderer->start_write();
       for (int i = 0; i < title_block->line_breaks.size() && y_offset + renderer->get_line_height() < text_height; i++)
       {
         title_block->render(renderer, i, text_xpos, text_ypos + y_offset);
         y_offset += renderer->get_line_height();
       }
+      renderer->end_write();
       delete title_block;
       delete epub;
     }

--- a/lib/Epub/RubbishHtmlParser/Page.h
+++ b/lib/Epub/RubbishHtmlParser/Page.h
@@ -56,10 +56,12 @@ public:
   std::vector<PageElement *> elements;
   void render(Renderer *renderer, Epub *epub)
   {
+    renderer->start_write();
     for (auto element : elements)
     {
       element->render(renderer, epub);
     }
+    renderer->end_write();
   }
   
   ~Page()

--- a/lib/Epub/RubbishHtmlParser/blocks/TextBlock.cpp
+++ b/lib/Epub/RubbishHtmlParser/blocks/TextBlock.cpp
@@ -206,7 +206,8 @@ void TextBlock::render(Renderer *renderer, int line_break_index, int x_pos, int 
   int start = line_break_index == 0 ? 0 : line_breaks[line_break_index - 1];
   int end = line_breaks[line_break_index];
   
-  renderer->start_write();
+  // Commenting this for now since makes other parts than the line quite grayish
+  //renderer->start_write();
   for (int i = start; i < end; i++)
   {
     // get the style
@@ -215,7 +216,7 @@ void TextBlock::render(Renderer *renderer, int line_break_index, int x_pos, int 
     renderer->draw_text(x_pos + word_xpos[i], y_pos, words[i], style & BOLD_SPAN, style & ITALIC_SPAN);
   }
   // Flush display
-  renderer->end_write();
+  //renderer->end_write();
 }
 // debug helper - dumps out the contents of the block with line breaks
 void TextBlock::dump()


### PR DESCRIPTION
This pull request is just to make rendering faster and try to eliminate some bugs found when it wakes up from deep-sleep.
Sometimes it renders books index again (but just with empty rectangles)